### PR TITLE
fixing tcflow and constants

### DIFF
--- a/src/TERMIOS.jl
+++ b/src/TERMIOS.jl
@@ -658,8 +658,8 @@ function testflow(fd, action, values)
 
     index = findfirst(x-> x == action, FLOWNAMES)
     off = index ÷ 2 * 2
-	ccall(:tcflow, Cint, (Cint, Cint), fd, values[off]) == -1 && return false
-	ccall(:tcflow, Cint, (Cint, Cint), fd, values[off + 1]) == -1 && return false
+    ccall(:tcflow, Cint, (Cint, Cint), fd, values[off]) == -1 && return false
+    ccall(:tcflow, Cint, (Cint, Cint), fd, values[off + 1]) == -1 && return false
     TCOOFF, TCOON, TCIOFF, TCION = values
     # call the correct action if the above succeeded
     ccall(:tcflow, Cint, (Cint, Cint), fd, values[index])

--- a/src/TERMIOS.jl
+++ b/src/TERMIOS.jl
@@ -441,7 +441,7 @@ FLOWVALUES = [
 # On Linux, start with symbol values
 # if tcflow is called, probe and set them to the correct values
 # these names correspond to the values above
-FLOWNAMES = [:TCOOFF, :TCOON, :TCIOFF, :TCIOF]
+FLOWNAMES = [:TCOOFF, :TCOON, :TCIOFF, :TCION]
 
 """Suspend output."""
 TCOOFF = Sys.islinux() ? :TCOOFF : 1
@@ -657,7 +657,7 @@ function testflow(fd, action, values)
     global TCOOFF, TCOON, TCIOFF, TCION, FLOWNAMES
 
     index = findfirst(x-> x == action, FLOWNAMES)
-    off = index ÷ 2 * 2
+    off = (index - 1) ÷ 2 * 2 + 1
     ccall(:tcflow, Cint, (Cint, Cint), fd, values[off]) == -1 && return false
     ccall(:tcflow, Cint, (Cint, Cint), fd, values[off + 1]) == -1 && return false
     TCOOFF, TCOON, TCIOFF, TCION = values

--- a/src/TERMIOS.jl
+++ b/src/TERMIOS.jl
@@ -432,16 +432,16 @@ const TCIOFLUSH = Sys.islinux() ? 2 : 3
 #
 
 """Suspend output."""
-const TCOOFF = Sys.islinux() ? 16 : 1
+const TCOOFF = Sys.islinux() ? 0 : 1
 
 """Restart suspended output."""
-const TCOON = Sys.islinux() ? 32 : 2
+const TCOON = Sys.islinux() ? 1 : 2
 
 """Send a STOP character."""
-const TCIOFF = Sys.islinux() ? 4 : 3
+const TCIOFF = Sys.islinux() ? 2 : 3
 
 """Send a START character."""
-const TCION = Sys.islinux() ? 8 : 4
+const TCION = Sys.islinux() ? 3 : 4
 
 ########################################################################################################################
 
@@ -652,7 +652,7 @@ Suspend transmission or reception of data on the object referred to by fd, depen
 - `TERMIOS.TCION` to restart input.
 """
 function tcflow(fd::RawFD, action::Integer)
-    r = ccall(:tcflush, Cint, (Cint, Cint), fd, action)
+    r = ccall(:tcflow, Cint, (Cint, Cint), fd, action)
     r == -1 ? throw(TERMIOSError("tcflow failed: $(Base.Libc.strerror())")) : nothing
 end
 tcflow(s::Base.LibuvStream, action) = tcflow(_file_handle(s), action)

--- a/src/TERMIOS.jl
+++ b/src/TERMIOS.jl
@@ -431,17 +431,29 @@ const TCIOFLUSH = Sys.islinux() ? 2 : 3
 # Values for the ACTION argument to `tcflow'.
 #
 
+# These action values are variables instead of constants because
+# the Linux values could be one of these sets
+FLOWVALUES = [
+    (0, 1, 2, 3),
+    (16, 32, 4, 8),
+]
+
+# On Linux, start with symbol values
+# if tcflow is called, probe and set them to the correct values
+# these names correspond to the values above
+FLOWNAMES = [:TCOOFF, :TCOON, :TCIOFF, :TCIOF]
+
 """Suspend output."""
-const TCOOFF = Sys.islinux() ? 0 : 1
+TCOOFF = Sys.islinux() ? :TCOOFF : 1
 
 """Restart suspended output."""
-const TCOON = Sys.islinux() ? 1 : 2
+TCOON = Sys.islinux() ? :TCOON : 2
 
 """Send a STOP character."""
-const TCIOFF = Sys.islinux() ? 2 : 3
+TCIOFF = Sys.islinux() ? :TCIOFF : 3
 
 """Send a START character."""
-const TCION = Sys.islinux() ? 3 : 4
+TCION = Sys.islinux() ? :TCION : 4
 
 ########################################################################################################################
 
@@ -640,6 +652,28 @@ function tcdrain(fd::RawFD)
 end
 tcdrain(s::Base.LibuvStream) = tcdrain(_file_handle(s))
 tcdrain(f::Int) = tcdrain(RawFD(f))
+
+function testflow(fd, action, values)
+    global TCOOFF, TCOON, TCIOFF, TCION, FLOWNAMES
+
+    index = findfirst(x-> x == action, FLOWNAMES)
+    off = index ÷ 2 * 2
+	ccall(:tcflow, Cint, (Cint, Cint), fd, values[off]) == -1 && return false
+	ccall(:tcflow, Cint, (Cint, Cint), fd, values[off + 1]) == -1 && return false
+    TCOOFF, TCOON, TCIOFF, TCION = values
+    # call the correct action if the above succeeded
+	ccall(:tcflow, Cint, (Cint, Cint), fd, values[index])
+    true
+end
+
+function tcflow(fd::RawFD, action::Symbol)
+    global FLOWVALUES
+
+    for values in FLOWVALUES
+        testflow(fd, action, values) && return
+    end
+    throw(TERMIOSError("tcflow failed, could not determine correct values for this host for TCOOFF, TCOON, TCIOFF, and TCION")) : nothing
+end
 
 """
     tcflow(s::Base.LibuvStream, action::Integer)

--- a/src/TERMIOS.jl
+++ b/src/TERMIOS.jl
@@ -662,7 +662,7 @@ function testflow(fd, action, values)
 	ccall(:tcflow, Cint, (Cint, Cint), fd, values[off + 1]) == -1 && return false
     TCOOFF, TCOON, TCIOFF, TCION = values
     # call the correct action if the above succeeded
-	ccall(:tcflow, Cint, (Cint, Cint), fd, values[index])
+    ccall(:tcflow, Cint, (Cint, Cint), fd, values[index])
     true
 end
 


### PR DESCRIPTION
The Linux values I've seen are not powers of 2 from 4-32 but
consecutive from 0-3, at least for Fedora, Debian, and Ubuntu.